### PR TITLE
Fixed Button component

### DIFF
--- a/plugin/components/Button.vue
+++ b/plugin/components/Button.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="button" :class="buttonSize">
+  <button class="button" :class="buttonSize">
     <slot>Button Label</slot>
-  </div>
+  </button>
 </template>
 
 <script>


### PR DESCRIPTION
Originally had the root element of the Button component as a `div` switched to `button` for obvious reasons...