### PR TITLE
Vue Component: Image Round

### DIFF
--- a/plugin/components/ImageRound.vue
+++ b/plugin/components/ImageRound.vue
@@ -1,0 +1,57 @@
+<template>
+  <div :class="imageSize">
+    <img :src="src" :alt="alt" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'image-round',
+  props: {
+    // Set the size of the round image
+    size: {
+      type: String,
+      default: 'image--round-medium',
+      required: true,
+      validator: function (value) {
+        return (
+          ['sm', 'md', 'lg' ].indexOf(
+            value
+          ) !== -1
+        );
+      },
+    },
+    // Set the img src attribute
+    src: {
+      type: String,
+      required: true,
+    },
+    // Set the img alt attribute
+    alt: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    imageSize() {
+      let className = 'image--round-medium';
+      if (this.size) {
+        switch (this.size) {
+          case 'sm':
+            className = 'image--round-small';
+            break;
+          case 'md':
+            className = 'image--round-medium';
+            break;
+          case 'lg':
+            className = 'image--round-large';
+            break;
+          default:
+            className = 'image--round-medium';
+        }
+      }
+      return className;
+    },
+  },
+};
+</script>

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -13,6 +13,7 @@ import DrawerHeader from './components/DrawerHeader.vue';
 import DrawerContent from './components/DrawerContent.vue';
 import Button from './components/Button.vue';
 import FigureHover from './components/FigureHover.vue';
+import ImageRound from './components/ImageRound.vue';
 import Menu from './components/Menu.vue';
 import MenuDropdown from './components/MenuDropdown.vue';
 import Blockquote from './components/Blockquote.vue';
@@ -34,6 +35,7 @@ export default {
     app.component('pui-drawer-header', DrawerHeader);
     app.component('pui-drawer-content', DrawerContent);
     app.component('pui-figure-hover', FigureHover);
+    app.component('pui-image-round', ImageRound);
     app.component('pui-menu', Menu);
     app.component('pui-menu-dropdown', MenuDropdown);
     app.component('pui-blockquote', Blockquote);

--- a/src/App.vue
+++ b/src/App.vue
@@ -210,6 +210,25 @@
         ></pui-figure-hover>
       </div>
     </div>
+
+    <div class="block-container m-2">
+      <div class="block laptop-up-4">
+        <h2 class="mt-6">Image Round</h2>
+        <pui-image-round
+          src="https://images.unsplash.com/photo-1477346611705-65d1883cee1e?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80"
+          size="sm">
+        </pui-image-round>
+        <pui-image-round
+          src="https://images.unsplash.com/photo-1477346611705-65d1883cee1e?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80"
+          size="md">
+        </pui-image-round>
+        <pui-image-round
+          src="https://images.unsplash.com/photo-1477346611705-65d1883cee1e?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80"
+          size="lg">
+        </pui-image-round>
+      </div>
+    </div>
+
   </div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -216,15 +216,18 @@
         <h2 class="mt-6">Image Round</h2>
         <pui-image-round
           src="https://images.unsplash.com/photo-1477346611705-65d1883cee1e?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80"
-          size="sm">
+          size="sm"
+          alt="Purple mountains">
         </pui-image-round>
         <pui-image-round
           src="https://images.unsplash.com/photo-1477346611705-65d1883cee1e?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80"
-          size="md">
+          size="md"
+          alt="Purple mountains">
         </pui-image-round>
         <pui-image-round
           src="https://images.unsplash.com/photo-1477346611705-65d1883cee1e?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80"
-          size="lg">
+          size="lg"
+          alt="Purple mountains">
         </pui-image-round>
       </div>
     </div>


### PR DESCRIPTION
Props:
- src - Set the img src attribute
- size - Set the size of the round image (sm, md, lg)
- alt - Set the img alt attribute

Code:
```html
<pui-image-round
  src="..."
  size="sm"
  alt="Purple mountains">
</pui-image-round>
<pui-image-round
  src="..."
  size="md"
  alt="Purple mountains">
</pui-image-round>
<pui-image-round
  src="..."
  size="lg"
  alt="Purple mountains">
</pui-image-round>
```

Screenshot:
![Screen Shot 2021-01-25 at 2 30 06 PM](https://user-images.githubusercontent.com/5217768/105755828-d3f80500-5f19-11eb-923d-c82509399c10.png)
