### PR TITLE
Update publish command and exclude files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ deploy_script:
       {
         "@ritterim:registry=https://ritterim.myget.org/F/npm/npm/`r`n//ritterim.myget.org/F/npm/npm/:_authToken=`$`{MYGET_TOKEN`}" | Out-File (Join-Path $ENV:APPVEYOR_BUILD_FOLDER ".npmrc") -Encoding UTF8
         iex "npm pack"
-        iex "npm publish ./dist"
+        iex "npm publish"
       }
     on:
       branch: master

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+./plugin
+./public
+./src
+./.appveyor.yml
+./babel.config.js
+./build.cmd


### PR DESCRIPTION
`./dist` directory was missing package.json file so publish failed on last build. This fixes it and also specifies which files at the root not to publish. 