### PR TITLE
Bug Fix: Buttons

### DIFF
--- a/plugin/components/Button.vue
+++ b/plugin/components/Button.vue
@@ -1,13 +1,12 @@
 <script>
 export default {
   name: 'pui-button',
-  inheritAttrs: false,
   render() {
-    const buttonClasses = 'button'.concat(this.buttonSize || '');
+    const buttonClasses = 'button'.concat(' ', this.buttonSize || '');
     return (
-      <div className={buttonClasses}>
+      <button class={buttonClasses}>
         {this.$slots.default()}
-      </div>
+      </button>
     );
   },
   props: {

--- a/plugin/components/Button.vue
+++ b/plugin/components/Button.vue
@@ -1,6 +1,7 @@
 <script>
 export default {
   name: 'pui-button',
+
   render() {
     const buttonClasses = 'button'.concat(' ', this.buttonSize || '');
     return (

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@
       <!-- Button -->
       <div class="block laptop-up-4 p-4">
         <h2>Button</h2>
-        <pui-button>This is a Button</pui-button>
+        <pui-button @click="buttonClick">This is a Button</pui-button>
         <pui-button size="lg">This is a Button</pui-button>
       </div>
     </div>
@@ -71,16 +71,18 @@
       <div class="block laptop-up-4 p-4">
         <h2>Drawer</h2>
         <div class="flex flex--align-center flex--justify-center flex--wrap">
-          <pui-button class="m-2" @click="toggleDrawer">Open Drawer</pui-button>
-          <pui-button class="m-2" @click="toggleSingleDrawer"
-            >Open Single Drawer</pui-button
-          >
-          <pui-button class="m-2" @click="toggleLeftDrawer"
-            >Open Left Drawer</pui-button
-          >
-          <pui-button class="m-2" @click="toggleRightDrawer"
-            >Open Right Drawer</pui-button
-          >
+          <pui-button class="m-2 background-blue" @click="toggleDrawer">
+            Open Drawer
+          </pui-button>
+          <pui-button class="m-2" @click="toggleSingleDrawer">
+            Open Single Drawer
+          </pui-button>
+          <pui-button class="m-2" @click="toggleLeftDrawer">
+            Open Left Drawer
+          </pui-button>
+          <pui-button class="m-2" @click="toggleRightDrawer">
+            Open Right Drawer
+          </pui-button>
         </div>
       </div>
 
@@ -95,7 +97,6 @@
     </div>
 
     <div class="block-container">
-
       <!-- Info Box -->
       <div class="block laptop-up-4 p-4">
         <h2>Info Box</h2>

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,7 +71,7 @@
       <div class="block laptop-up-4 p-4">
         <h2>Drawer</h2>
         <div class="flex flex--align-center flex--justify-center flex--wrap">
-          <pui-button class="m-2 background-blue" @click="toggleDrawer">
+          <pui-button class="m-2" @click="toggleDrawer">
             Open Drawer
           </pui-button>
           <pui-button class="m-2" @click="toggleSingleDrawer">


### PR DESCRIPTION
Issues:
- Could not use Vue `@click` handler on buttons
- Could not apply any other classes to buttons
- Adding `size="lg"` prop broke button
- Component was using a `div` element instead of `button`

Changes:
- Changed element to `button`
- Removed ` inheritAttrs: false` - this now allows the button to use `@click`
- Added space when concatenating classes for `button-lg`
- Changed `className` attribute to just `class`

![Screen Shot 2021-02-02 at 10 04 14 AM](https://user-images.githubusercontent.com/5217768/106618904-0323fd00-653e-11eb-8e75-eb276324f852.png)
